### PR TITLE
connect: add 250ms timeout in each connection attempt loop

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -391,6 +391,7 @@ func (c *Conn) connect() error {
 		}
 
 		c.logger.Printf("failed to connect to %s: %v", c.Server(), err)
+		time.Sleep(250 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
Observed an issue in production where, if a TCP connection to a Zookeeper node
could not be established (due to ZK being down or DNS resolution problem),
connect() would infinite-retry with no timeout and flood the DNS server and
Zookeeper node with an abnormal number of requests (>1000/sec).

J=SRE-3085
TEST=manual
  Added blackhole of zookeeper server addresses to 0.0.0.0 in /etc/hosts to simulate
  zookeeper not being resolvable in DNS or immediately rejecting the TCP connection.

  Ran service and performed RPC request, verified that it waited between each
  failed connection attempt rather than immediately retrying like before.