### PR TITLE
Update go.mod with correct module name

### DIFF
--- a/_examples/basic.go
+++ b/_examples/basic.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-zookeeper/zk"
+	"github.com/yext/zk"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/go-zookeeper/zk
+module github.com/yext/zk
 
-go 1.13
+go 1.15


### PR DESCRIPTION
This change allows this repository to be used with go modules.

It also bumps the compatible Go version to 1.15